### PR TITLE
feat: payments PoC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ env:
   RUST_LOG: "gadget=debug"
   CARGO_TERM_COLOR: always
   TANGLE_RELEASE: "v1.2.3"
+  SIGNER: "//Alice"
+  EVM_SIGNER: "0xcb6df9de1efca7a3998a8ead4e02159d5fa99c3e0d4fd6432667390bb4726854"
 
 jobs:
   fmt:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,8 @@ jobs:
       - name: Forge build
         run: forge update && forge build
 
+      - uses: taiki-e/github-actions/free-device-space@main
+
       - name: Run Clippy
         run: cargo clippy --tests --examples -- -D warnings
 
@@ -101,6 +103,8 @@ jobs:
 
       - name: Forge build
         run: forge update && forge build
+
+      - uses: taiki-e/github-actions/free-device-space@main
 
       - name: tests
         run: cargo nextest run
@@ -184,6 +188,8 @@ jobs:
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           # Check the Tangle node version
           tangle --version
+
+      - uses: taiki-e/github-actions/free-device-space@main
 
       - name: Build Blueprint
         run: cargo build --features e2e

--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -2,9 +2,9 @@ name: Foundry CI
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
   push:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
@@ -39,10 +39,42 @@ jobs:
       - name: Run Forge build
         run: |
           forge --version
-          forge build --sizes
+          forge build --sizes --color always
         id: build
 
       - name: Run Forge tests
         run: |
-          forge test -vvv
+          forge test -vvv --color always
         id: test
+  coverage_report:
+    name: Generate coverage report
+    needs: foundry-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Install Solidity Dependencies
+        run: forge soldeer update -d
+
+      - name: Setup LCOV
+        uses: hrishikesh-kadam/setup-lcov@v1
+
+      - name: Run Forge Coverage
+        run: forge coverage --color always --report lcov
+        id: coverage
+
+      - name: Report code coverage
+        uses: zgosalvez/github-actions-report-lcov@v3
+        with:
+          coverage-files: lcov.info
+          minimum-coverage: 85
+          artifact-name: code-coverage-report
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          update-comment: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,8 +163,8 @@ dependencies = [
  "alloy-primitives 0.7.7",
  "alloy-provider",
  "alloy-rpc-types-eth",
- "alloy-sol-types",
- "alloy-transport",
+ "alloy-sol-types 0.7.7",
+ "alloy-transport 0.1.4",
  "futures",
  "futures-util",
  "thiserror",
@@ -179,7 +179,7 @@ dependencies = [
  "alloy-json-abi",
  "alloy-primitives 0.7.7",
  "alloy-sol-type-parser",
- "alloy-sol-types",
+ "alloy-sol-types 0.7.7",
  "const-hex",
  "itoa",
  "serde",
@@ -228,6 +228,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-json-rpc"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fa8a1a3c4cbd221f2b8e3693aeb328fca79a757fe556ed08e47bbbc2a70db7"
+dependencies = [
+ "alloy-primitives 0.8.11",
+ "alloy-sol-types 0.8.11",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "alloy-network"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,12 +249,12 @@ checksum = "25f6895fc31b48fa12306ef9b4f78b7764f8bd6d7d91cdb0a40e233704a0f23f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-json-rpc",
+ "alloy-json-rpc 0.1.4",
  "alloy-primitives 0.7.7",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "alloy-signer",
- "alloy-sol-types",
+ "alloy-sol-types 0.7.7",
  "async-trait",
  "auto_impl",
  "futures-utils-wasm",
@@ -275,14 +289,25 @@ version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd58d377699e6cfeab52c4a9d28bdc4ef37e2bd235ff2db525071fe37a2e9af5"
 dependencies = [
+ "alloy-rlp",
  "bytes",
  "cfg-if",
  "const-hex",
  "derive_more 1.0.0",
+ "foldhash",
+ "hashbrown 0.15.1",
  "hex-literal",
+ "indexmap 2.6.0",
  "itoa",
+ "k256",
+ "keccak-asm",
  "paste",
+ "proptest",
+ "rand",
  "ruint",
+ "rustc-hash 2.0.0",
+ "serde",
+ "sha3",
  "tiny-keccak",
 ]
 
@@ -295,14 +320,14 @@ dependencies = [
  "alloy-chains",
  "alloy-consensus",
  "alloy-eips",
- "alloy-json-rpc",
+ "alloy-json-rpc 0.1.4",
  "alloy-network",
  "alloy-primitives 0.7.7",
  "alloy-pubsub",
- "alloy-rpc-client",
+ "alloy-rpc-client 0.1.4",
  "alloy-rpc-types-eth",
- "alloy-transport",
- "alloy-transport-http",
+ "alloy-transport 0.1.4",
+ "alloy-transport-http 0.1.4",
  "alloy-transport-ws",
  "async-stream",
  "async-trait",
@@ -326,16 +351,16 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a7341322d9bc0e49f6e9fd9f2eb8e30f73806f2dd12cbb3d6bab2694c921f87"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 0.1.4",
  "alloy-primitives 0.7.7",
- "alloy-transport",
+ "alloy-transport 0.1.4",
  "bimap",
  "futures",
  "serde",
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.4.13",
  "tracing",
 ]
 
@@ -367,11 +392,11 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ba31bae67773fd5a60020bea900231f8396202b7feca4d0c70c6b59308ab4a8"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 0.1.4",
  "alloy-primitives 0.7.7",
  "alloy-pubsub",
- "alloy-transport",
- "alloy-transport-http",
+ "alloy-transport 0.1.4",
+ "alloy-transport-http 0.1.4",
  "alloy-transport-ws",
  "futures",
  "hyper-util",
@@ -381,7 +406,29 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.4.13",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "alloy-rpc-client"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "370143ed581aace6e663342d21d209c6b2e34ee6142f7d6675adb518deeaf0dc"
+dependencies = [
+ "alloy-json-rpc 0.4.2",
+ "alloy-primitives 0.8.11",
+ "alloy-transport 0.4.2",
+ "alloy-transport-http 0.4.2",
+ "futures",
+ "pin-project",
+ "reqwest 0.12.9",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.1",
  "tracing",
  "url",
 ]
@@ -407,7 +454,7 @@ dependencies = [
  "alloy-primitives 0.7.7",
  "alloy-rlp",
  "alloy-serde",
- "alloy-sol-types",
+ "alloy-sol-types 0.7.7",
  "itertools 0.13.0",
  "serde",
  "serde_json",
@@ -479,9 +526,23 @@ version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b40397ddcdcc266f59f959770f601ce1280e699a91fc1862f29cef91707cd09"
 dependencies = [
- "alloy-sol-macro-expander",
- "alloy-sol-macro-input",
+ "alloy-sol-macro-expander 0.7.7",
+ "alloy-sol-macro-input 0.7.7",
  "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "alloy-sol-macro"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a1b42ac8f45e2f49f4bcdd72cbfde0bb148f5481d403774ffa546e48b83efc1"
+dependencies = [
+ "alloy-sol-macro-expander 0.8.11",
+ "alloy-sol-macro-input 0.8.11",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -494,7 +555,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "867a5469d61480fea08c7333ffeca52d5b621f5ca2e44f271b117ec1fc9a0525"
 dependencies = [
  "alloy-json-abi",
- "alloy-sol-macro-input",
+ "alloy-sol-macro-input 0.7.7",
  "const-hex",
  "heck 0.5.0",
  "indexmap 2.6.0",
@@ -502,7 +563,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.87",
- "syn-solidity",
+ "syn-solidity 0.7.7",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-sol-macro-expander"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06318f1778e57f36333e850aa71bd1bb5e560c10279e236622faae0470c50412"
+dependencies = [
+ "alloy-sol-macro-input 0.8.11",
+ "const-hex",
+ "heck 0.5.0",
+ "indexmap 2.6.0",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "syn-solidity 0.8.11",
  "tiny-keccak",
 ]
 
@@ -520,7 +599,22 @@ dependencies = [
  "quote",
  "serde_json",
  "syn 2.0.87",
- "syn-solidity",
+ "syn-solidity 0.7.7",
+]
+
+[[package]]
+name = "alloy-sol-macro-input"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaebb9b0ad61a41345a22c9279975c0cdd231b97947b10d7aad1cf0a7181e4a5"
+dependencies = [
+ "const-hex",
+ "dunce",
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "syn-solidity 0.8.11",
 ]
 
 [[package]]
@@ -541,9 +635,20 @@ checksum = "a91ca40fa20793ae9c3841b83e74569d1cc9af29a2f5237314fd3452d51e38c7"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives 0.7.7",
- "alloy-sol-macro",
+ "alloy-sol-macro 0.7.7",
  "const-hex",
  "serde",
+]
+
+[[package]]
+name = "alloy-sol-types"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "374d7fb042d68ddfe79ccb23359de3007f6d4d53c13f703b64fb0db422132111"
+dependencies = [
+ "alloy-primitives 0.8.11",
+ "alloy-sol-macro 0.8.11",
+ "const-hex",
 ]
 
 [[package]]
@@ -552,7 +657,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01b51a291f949f755e6165c3ed562883175c97423703703355f4faa4b7d0a57c"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 0.1.4",
  "base64 0.22.1",
  "futures-util",
  "futures-utils-wasm",
@@ -560,7 +665,26 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "tower",
+ "tower 0.4.13",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "alloy-transport"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac3e97dad3d31770db0fc89bd6a63b789fbae78963086733f960cf32c483904"
+dependencies = [
+ "alloy-json-rpc 0.4.2",
+ "base64 0.22.1",
+ "futures-util",
+ "futures-utils-wasm",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tower 0.5.1",
  "tracing",
  "url",
 ]
@@ -571,14 +695,29 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86d65871f9f1cafe1ed25cde2f1303be83e6473e995a2d56c275ae4fcce6119c"
 dependencies = [
- "alloy-json-rpc",
- "alloy-transport",
+ "alloy-json-rpc 0.1.4",
+ "alloy-transport 0.1.4",
  "http-body-util",
  "hyper 1.5.0",
  "hyper-util",
  "reqwest 0.12.9",
  "serde_json",
- "tower",
+ "tower 0.4.13",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "alloy-transport-http"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b367dcccada5b28987c2296717ee04b9a5637aacd78eacb1726ef211678b5212"
+dependencies = [
+ "alloy-json-rpc 0.4.2",
+ "alloy-transport 0.4.2",
+ "reqwest 0.12.9",
+ "serde_json",
+ "tower 0.5.1",
  "tracing",
  "url",
 ]
@@ -590,7 +729,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aec83fd052684556c78c54df111433493267234d82321c2236560c752f595f20"
 dependencies = [
  "alloy-pubsub",
- "alloy-transport",
+ "alloy-transport 0.1.4",
  "futures",
  "http 1.1.0",
  "rustls 0.23.16",
@@ -1825,8 +1964,8 @@ dependencies = [
  "alloy-provider",
  "alloy-rpc-types",
  "alloy-rpc-types-eth",
- "alloy-sol-types",
- "alloy-transport",
+ "alloy-sol-types 0.7.7",
+ "alloy-transport 0.1.4",
  "async-trait",
  "blueprint-manager",
  "cargo-tangle",
@@ -3276,7 +3415,7 @@ dependencies = [
  "alloy-provider",
  "alloy-rpc-types-eth",
  "alloy-signer-local",
- "alloy-transport-http",
+ "alloy-transport-http 0.1.4",
  "eigen-logging",
  "eigen-signer",
  "k256",
@@ -3331,14 +3470,14 @@ checksum = "afc00e0508a9137355212339d6bc0b83b3ceb7dc4f541ec920e66171295bd9c3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-json-rpc",
+ "alloy-json-rpc 0.1.4",
  "alloy-primitives 0.7.7",
  "alloy-provider",
  "alloy-pubsub",
  "alloy-rlp",
  "alloy-rpc-types-eth",
- "alloy-transport",
- "alloy-transport-http",
+ "alloy-transport 0.1.4",
+ "alloy-transport-http 0.1.4",
  "alloy-transport-ws",
  "async-trait",
  "eigen-logging",
@@ -3525,7 +3664,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-network",
  "alloy-primitives 0.7.7",
- "alloy-rpc-client",
+ "alloy-rpc-client 0.1.4",
  "alloy-signer",
  "alloy-signer-aws",
  "alloy-signer-local",
@@ -3546,7 +3685,7 @@ dependencies = [
  "alloy-network",
  "alloy-primitives 0.7.7",
  "alloy-provider",
- "alloy-transport-http",
+ "alloy-transport-http 0.1.4",
  "eigen-utils",
  "once_cell",
  "serde",
@@ -3577,14 +3716,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "781a0d9bc2ab3d3709a1d6b23dfca5c2ef2da29b38f10a04bf7f1991bb53293e"
 dependencies = [
  "alloy-contract",
- "alloy-json-rpc",
+ "alloy-json-rpc 0.1.4",
  "alloy-network",
  "alloy-provider",
  "alloy-pubsub",
  "alloy-signer-local",
- "alloy-sol-types",
- "alloy-transport",
- "alloy-transport-http",
+ "alloy-sol-types 0.7.7",
+ "alloy-transport 0.1.4",
+ "alloy-transport-http 0.1.4",
  "reqwest 0.12.9",
 ]
 
@@ -4365,6 +4504,15 @@ dependencies = [
 name = "frost-blueprint"
 version = "0.1.0"
 dependencies = [
+ "alloy-contract",
+ "alloy-json-abi",
+ "alloy-network",
+ "alloy-primitives 0.7.7",
+ "alloy-provider",
+ "alloy-rpc-client 0.4.2",
+ "alloy-signer",
+ "alloy-signer-local",
+ "alloy-sol-types 0.7.7",
  "async-trait",
  "blueprint-metadata",
  "blueprint-test-utils",
@@ -4754,9 +4902,9 @@ dependencies = [
  "alloy-rpc-types",
  "alloy-signer",
  "alloy-signer-local",
- "alloy-sol-types",
- "alloy-transport",
- "alloy-transport-http",
+ "alloy-sol-types 0.7.7",
+ "alloy-transport 0.1.4",
+ "alloy-transport-http 0.1.4",
  "ark-bn254",
  "ark-ec",
  "ark-ff 0.4.2",
@@ -5260,6 +5408,7 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
+ "serde",
 ]
 
 [[package]]
@@ -6319,7 +6468,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "tower",
+ "tower 0.4.13",
  "tracing",
  "url",
 ]
@@ -8898,6 +9047,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9105,6 +9276,7 @@ dependencies = [
  "libc",
  "rand_chacha",
  "rand_core 0.6.4",
+ "serde",
 ]
 
 [[package]]
@@ -11703,7 +11875,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02f31217207638b7cba9751cedb9ddb612478423d7bf8700091cf1f9970bbc5f"
 dependencies = [
  "alloy-contract",
- "alloy-sol-types",
+ "alloy-sol-types 0.7.7",
  "serde",
 ]
 
@@ -11734,6 +11906,18 @@ name = "syn-solidity"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c837dc8852cb7074e46b444afb81783140dab12c58867b49fb3898fbafedf7ea"
+dependencies = [
+ "paste",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "syn-solidity"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edf42e81491fb8871b74df3d222c64ae8cbc1269ea509fa768a3ed3e1b0ac8cb"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -12282,6 +12466,20 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper 0.1.2",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,13 +63,27 @@ features = ["getrandom"]
 
 [dev-dependencies]
 tokio = { version = "^1", default-features = false, features = ["full", "rt-multi-thread"] }
-frost-core = { version = "2.0", default-features = false, features = ["serialization", "cheater-detection", "internals"] }
+frost-core = { version = "2.0", default-features = false, features = [
+    "serialization",
+    "cheater-detection",
+    "internals",
+] }
 round-based = { version = "0.3.0", default-features = false, features = ["derive", "dev"] }
 proptest = { version = "1.5.0", default-features = false, features = ["std", "bit-set", "fork", "timeout"] }
 test-strategy = { version = "0.4.0", default-features = false }
 
 cargo-tangle = "0.2"
 blueprint-test-utils = { version = "0.1", default-features = false, features = ["std"] }
+
+alloy-primitives = "0.7.2"
+alloy-provider = { version = "0.1", default-features = false, features = ["reqwest", "ws"] }
+alloy-signer = { version = "0.1" }
+alloy-signer-local = { version = "0.1" }
+alloy-rpc-client = "0.4.2"
+alloy-network = { version = "0.1" }
+alloy-json-abi = "0.7.2"
+alloy-sol-types = "0.7.2"
+alloy-contract = { version = "0.1" }
 
 [build-dependencies]
 blueprint-metadata = "0.1.6"

--- a/contracts/src/FrostBlueprint.sol
+++ b/contracts/src/FrostBlueprint.sol
@@ -2,13 +2,78 @@
 pragma solidity >=0.8.13;
 
 import "tnt-core/BlueprintServiceManagerBase.sol";
+import "@openzeppelin/contracts/utils/structs/EnumerableMap.sol";
+
+import "@src/payments/IPaymentManager.sol";
+import "@src/payments/PaymentManagerBase.sol";
 
 /**
  * @title FrostBlueprint
  * @dev This contract is a blueprint for a FROST service. It extends the
  * `BlueprintServiceManagerBase` contract, which provides the basic functionality
  */
-contract FrostBlueprint is BlueprintServiceManagerBase {
+contract FrostBlueprint is BlueprintServiceManagerBase, PaymentManagerBase {
+    using EnumerableSet for EnumerableSet.AddressSet;
+    using EnumerableMap for EnumerableMap.UintToAddressMap;
+    using EnumerableMap for EnumerableMap.AddressToUintMap;
+
+    // =============== CONSTANTS ======================
+
+    /// @dev The IERC20 contract's address of TNT.
+    ///
+    /// TODO: move this into the TNT core contracts.
+    address constant TNT_ERC20_ADDRESS = 0x0000000000000000000000000000000000000802;
+
+    /// @dev The Job Id for `keygen` job.
+    uint8 constant KEYGEN_JOB_ID = 0;
+    /// @dev The Job Id for `sign` job.
+    uint8 constant SIGN_JOB_ID = 1;
+
+    /// @dev Keygen Job Avarage duration in seconds.
+    uint256 constant KEYGEN_JOB_DURATION_SECS = 5 seconds;
+    /// @dev Sign Job Avarage duration in seconds.
+    uint256 constant SIGN_JOB_DURATION_SECS = 3 seconds;
+
+    // ================ STORAGE =======================
+
+    /// @dev Mapping of service IDs to service operators addresses
+    mapping(uint64 => EnumerableSet.AddressSet) private _serviceOperators;
+
+    /// @dev Mapping from job id to the amount of tokens required for the job.
+    /// This is used to determine the amount of tokens to be transferred from the
+    /// service owner balance to the operator balance.
+    EnumerableMap.AddressToUintMap private _keygenJobCost;
+    EnumerableMap.AddressToUintMap private _signJobCost;
+
+    // ================ EVENTS ========================
+    event OperatorRegistered(address operator);
+    event ServiceOperatorAdded(uint64 indexed serviceId, address indexed operator);
+
+    // ================ ERRORS ========================
+    error OperatorNotRegistered(address operator);
+    error OperatorAlreadyAdded(uint64 serviceId, address operator);
+    error UnsupportedJob(uint8 job);
+    error InvalidECDSAPublicKey(bytes publicKey);
+    error InvalidECDSASignature(bytes signature);
+
+    /**
+     * @dev Constructor for the FrostBlueprint contract
+     */
+    constructor() PaymentManagerBase(_msgSender()) {
+        // Grant Root Chain role to the runtime.
+        grantRole(ROOT_CHAIN_ROLE, ROOT_CHAIN);
+        // Also Make it an Admin.
+        grantRole(DEFAULT_ADMIN_ROLE, ROOT_CHAIN);
+        // Add TNT as a supported token for payments by default.
+        address[] memory supportedTokens = new address[](1);
+        supportedTokens[0] = TNT_ERC20_ADDRESS;
+        addSupportedTokens(supportedTokens);
+
+        // Set the cost of the jobs.
+        _keygenJobCost.set(TNT_ERC20_ADDRESS, 0.001 ether);
+        _signJobCost.set(TNT_ERC20_ADDRESS, 0.00001 ether);
+    }
+
     /**
      * @dev Hook for service operator registration. Called when a service operator
      * attempts to register with the blueprint.
@@ -21,7 +86,8 @@ contract FrostBlueprint is BlueprintServiceManagerBase {
         override
         onlyFromRootChain
     {
-        // Do something with the operator's details
+        // Grant the operator the OPERATOR_ROLE.
+        grantRole(OPERATOR_ROLE, operatorAddressFromPublicKey(operator));
     }
 
     /**
@@ -37,7 +103,13 @@ contract FrostBlueprint is BlueprintServiceManagerBase {
         override
         onlyFromRootChain
     {
-        // Do something with the service request
+        // TODO: once we have access to the service owner, we can use it
+        // to verify the service request and payment.
+        // See: https://github.com/tangle-network/tangle/issues/817
+        uint256 operatorsCount = operators.length;
+        for (uint256 i = 0; i < operatorsCount; i++) {
+            _addServiceOperator(serviceId, operatorAddressFromPublicKey(operators[i]));
+        }
     }
 
     /**
@@ -45,28 +117,170 @@ contract FrostBlueprint is BlueprintServiceManagerBase {
      * of a job execution.
      * @param serviceId The ID of the service related to the job.
      * @param job The job identifier.
-     * @param _jobCallId The unique ID for the job call.
+     * @param jobCallId The unique ID for the job call.
      * @param participant The participant (operator) sending the result.
-     * @param _inputs Inputs used for the job execution.
-     * @param _outputs Outputs resulting from the job execution.
+     * @param inputs Inputs used for the job execution.
+     * @param outputs Outputs resulting from the job execution.
      */
     function onJobResult(
         uint64 serviceId,
         uint8 job,
-        uint64 _jobCallId,
+        uint64 jobCallId,
         bytes calldata participant,
-        bytes calldata _inputs,
-        bytes calldata _outputs
+        bytes calldata inputs,
+        bytes calldata outputs
     ) public payable virtual override onlyFromRootChain {
-        // Do something with the job call result
+        if (job == KEYGEN_JOB_ID) {
+            _handleKeygenJobResult(serviceId, jobCallId, operatorAddressFromPublicKey(participant), inputs, outputs);
+        } else if (job == SIGN_JOB_ID) {
+            _handleSignJobResult(serviceId, jobCallId, operatorAddressFromPublicKey(participant), inputs, outputs);
+        } else {
+            revert UnsupportedJob(job);
+        }
+    }
+
+    /**
+     * @dev Implement the calculateServiceCost function.
+     */
+    function calculateServiceCost(uint256 serviceDuration, address token) external view override returns (uint256) {
+        uint256 cost = 0;
+        uint256 oneKeygenCall = _jobCost(KEYGEN_JOB_ID, token);
+        uint256 oneSignCall = _jobCost(SIGN_JOB_ID, token);
+        cost += oneKeygenCall + oneSignCall;
+        return cost * serviceDuration;
+    }
+
+    /**
+     * @dev Get the cost of a job per sec in a given token.
+     * @param jobId uint8 The job identifier.
+     * @param token address The token address.
+     * @return cost uint256 The cost of the job per sec in the given token.
+     */
+    function jobCost(uint8 jobId, address token) external view returns (uint256) {
+        return _jobCost(jobId, token);
+    }
+
+    /**
+     * @dev Get Service operators for a given service ID.
+     * @param serviceId uint64 The service ID.
+     * @return operators address[] The operators for the given service ID.
+     */
+    function serviceOperators(uint64 serviceId) external view returns (address[] memory) {
+        return _serviceOperators[serviceId].values();
+    }
+
+    /**
+     * @dev Update the cost of a job.
+     * @param jobId uint8 The job identifier.
+     * @param token address The token address.
+     * @param cost uint256 The new cost of the job per sec in the given token.
+     */
+    function updateJobCost(uint8 jobId, address token, uint256 cost) external onlyOwner {
+        if (jobId == KEYGEN_JOB_ID) {
+            _keygenJobCost.set(token, cost);
+        } else if (jobId == SIGN_JOB_ID) {
+            _signJobCost.set(token, cost);
+        } else {
+            revert UnsupportedJob(jobId);
+        }
     }
 
     /**
      * @dev Converts a public key to an operator address.
-     * @param publicKey The public key to convert.
+     * @param publicKey bytes The public key to convert.
      * @return operator address The operator address.
      */
-    function operatorAddressFromPublicKey(bytes calldata publicKey) internal pure returns (address operator) {
+    function operatorAddressFromPublicKey(bytes calldata publicKey) public pure returns (address operator) {
         return address(uint160(uint256(keccak256(publicKey))));
+    }
+
+    /**
+     * @dev Add a service operator to the service.
+     * @param serviceId The ID of the service.
+     * @param operator The operator to add.
+     */
+    function _addServiceOperator(uint64 serviceId, address operator) internal {
+        if (!hasRole(OPERATOR_ROLE, operator)) {
+            revert OperatorNotRegistered(operator);
+        }
+
+        bool added = _serviceOperators[serviceId].add(operator);
+        if (!added) {
+            revert OperatorAlreadyAdded(serviceId, operator);
+        }
+    }
+
+    /**
+     * @dev Handle the result of a `keygen` job.
+     * @param serviceId uint64 The ID of the service.
+     * @param _jobCallId uint64 The ID of the job call.
+     * @param operator address The operator who executed the job.
+     * @param _inputs bytes The inputs used for the job execution.
+     * @param outputs bytes The outputs resulting from the job execution.
+     */
+    function _handleKeygenJobResult(
+        uint64 serviceId,
+        uint64 _jobCallId,
+        address operator,
+        bytes calldata _inputs,
+        bytes calldata outputs
+    ) internal {
+        if (outputs.length != 33) {
+            revert InvalidECDSAPublicKey(outputs);
+        }
+        uint256 operatorsCount = _serviceOperators[serviceId].length();
+        address[] memory _tokens = supportedTokens();
+        for (uint256 i = 0; i < _tokens.length; i++) {
+            address token = _tokens[i];
+            uint256 tokensPerSec = _jobCost(KEYGEN_JOB_ID, token);
+            uint256 amount = tokensPerSec * KEYGEN_JOB_DURATION_SECS * operatorsCount;
+            creditOperator(operator, token, amount);
+        }
+    }
+
+    /**
+     * @dev Handle the result of a `sign` job.
+     * @param _serviceId uint64 The ID of the service.
+     * @param _jobCallId uint64 The ID of the job call.
+     * @param operator address The operator who executed the job.
+     * @param inputs bytes The inputs used for the job execution.
+     * @param outputs bytes The outputs resulting from the job execution.
+     */
+    function _handleSignJobResult(
+        uint64 _serviceId,
+        uint64 _jobCallId,
+        address operator,
+        bytes calldata inputs,
+        bytes calldata outputs
+    ) internal {
+        (bytes memory _publicKey, bytes memory _msg) = abi.decode(inputs, (bytes, bytes));
+        bytes memory signature = abi.decode(outputs, (bytes));
+        if (signature.length != 65) {
+            revert InvalidECDSASignature(signature);
+        }
+        // TODO: verify the signature
+        address[] memory _tokens = supportedTokens();
+        for (uint256 i = 0; i < _tokens.length; i++) {
+            address token = _tokens[i];
+            uint256 tokensPerSec = _jobCost(SIGN_JOB_ID, token);
+            uint256 amount = tokensPerSec * SIGN_JOB_DURATION_SECS;
+            creditOperator(operator, token, amount);
+        }
+    }
+
+    /**
+     * @dev Get the Job Cost by Job ID and Token Address
+     * @param jobId uint8 The ID of the job.
+     * @param token address The token address.
+     * @return amount uint256 The amount of the token required for the job.
+     */
+    function _jobCost(uint8 jobId, address token) internal view returns (uint256 amount) {
+        if (jobId == KEYGEN_JOB_ID) {
+            return _keygenJobCost.get(token);
+        } else if (jobId == SIGN_JOB_ID) {
+            return _signJobCost.get(token);
+        } else {
+            revert UnsupportedJob(jobId);
+        }
     }
 }

--- a/contracts/src/FrostBlueprint.sol
+++ b/contracts/src/FrostBlueprint.sol
@@ -39,6 +39,9 @@ contract FrostBlueprint is BlueprintServiceManagerBase, PaymentManagerBase {
     /// @dev Mapping of service IDs to service operators addresses
     mapping(uint64 => EnumerableSet.AddressSet) private _serviceOperators;
 
+    /// @dev Mapping of service id to the service supported assets.
+    /// TODO: This could be moved to the service manager contract.
+
     /// @dev Mapping from job id to the amount of tokens required for the job.
     /// This is used to determine the amount of tokens to be transferred from the
     /// service owner balance to the operator balance.
@@ -54,7 +57,6 @@ contract FrostBlueprint is BlueprintServiceManagerBase, PaymentManagerBase {
     error OperatorAlreadyAdded(uint64 serviceId, address operator);
     error UnsupportedJob(uint8 job);
     error InvalidECDSAPublicKey();
-    error InvalidECDSASignature();
 
     /**
      * @dev Constructor for the FrostBlueprint contract
@@ -225,7 +227,8 @@ contract FrostBlueprint is BlueprintServiceManagerBase, PaymentManagerBase {
         bytes calldata _inputs,
         bytes calldata outputs
     ) internal {
-        if (outputs.length != 33) {
+        bytes32 pubkey = abi.decode(outputs, (bytes32));
+        if (outputs.length != 32) {
             revert InvalidECDSAPublicKey();
         }
         uint256 operatorsCount = _serviceOperators[serviceId].length();
@@ -253,11 +256,6 @@ contract FrostBlueprint is BlueprintServiceManagerBase, PaymentManagerBase {
         bytes calldata inputs,
         bytes calldata outputs
     ) internal {
-        (bytes memory _publicKey, bytes memory _msg) = abi.decode(inputs, (bytes, bytes));
-        bytes memory signature = abi.decode(outputs, (bytes));
-        if (signature.length != 65) {
-            revert InvalidECDSASignature();
-        }
         // TODO: verify the signature
         address[] memory _tokens = supportedTokens();
         for (uint256 i = 0; i < _tokens.length; i++) {

--- a/contracts/src/FrostBlueprint.sol
+++ b/contracts/src/FrostBlueprint.sol
@@ -4,8 +4,8 @@ pragma solidity >=0.8.13;
 import "tnt-core/BlueprintServiceManagerBase.sol";
 import "@openzeppelin/contracts/utils/structs/EnumerableMap.sol";
 
-import "@src/payments/IPaymentManager.sol";
-import "@src/payments/PaymentManagerBase.sol";
+import "./payments/IPaymentManager.sol";
+import "./payments/PaymentManagerBase.sol";
 
 /**
  * @title FrostBlueprint
@@ -22,17 +22,17 @@ contract FrostBlueprint is BlueprintServiceManagerBase, PaymentManagerBase {
     /// @dev The IERC20 contract's address of TNT.
     ///
     /// TODO: move this into the TNT core contracts.
-    address constant TNT_ERC20_ADDRESS = 0x0000000000000000000000000000000000000802;
+    address public constant TNT_ERC20_ADDRESS = 0x0000000000000000000000000000000000000802;
 
     /// @dev The Job Id for `keygen` job.
-    uint8 constant KEYGEN_JOB_ID = 0;
+    uint8 public constant KEYGEN_JOB_ID = 0;
     /// @dev The Job Id for `sign` job.
-    uint8 constant SIGN_JOB_ID = 1;
+    uint8 public constant SIGN_JOB_ID = 1;
 
     /// @dev Keygen Job Avarage duration in seconds.
-    uint256 constant KEYGEN_JOB_DURATION_SECS = 5 seconds;
+    uint256 public constant KEYGEN_JOB_DURATION_SECS = 5 seconds;
     /// @dev Sign Job Avarage duration in seconds.
-    uint256 constant SIGN_JOB_DURATION_SECS = 3 seconds;
+    uint256 public constant SIGN_JOB_DURATION_SECS = 3 seconds;
 
     // ================ STORAGE =======================
 
@@ -53,8 +53,8 @@ contract FrostBlueprint is BlueprintServiceManagerBase, PaymentManagerBase {
     error OperatorNotRegistered(address operator);
     error OperatorAlreadyAdded(uint64 serviceId, address operator);
     error UnsupportedJob(uint8 job);
-    error InvalidECDSAPublicKey(bytes publicKey);
-    error InvalidECDSASignature(bytes signature);
+    error InvalidECDSAPublicKey();
+    error InvalidECDSASignature();
 
     /**
      * @dev Constructor for the FrostBlueprint contract
@@ -226,7 +226,7 @@ contract FrostBlueprint is BlueprintServiceManagerBase, PaymentManagerBase {
         bytes calldata outputs
     ) internal {
         if (outputs.length != 33) {
-            revert InvalidECDSAPublicKey(outputs);
+            revert InvalidECDSAPublicKey();
         }
         uint256 operatorsCount = _serviceOperators[serviceId].length();
         address[] memory _tokens = supportedTokens();
@@ -256,7 +256,7 @@ contract FrostBlueprint is BlueprintServiceManagerBase, PaymentManagerBase {
         (bytes memory _publicKey, bytes memory _msg) = abi.decode(inputs, (bytes, bytes));
         bytes memory signature = abi.decode(outputs, (bytes));
         if (signature.length != 65) {
-            revert InvalidECDSASignature(signature);
+            revert InvalidECDSASignature();
         }
         // TODO: verify the signature
         address[] memory _tokens = supportedTokens();

--- a/contracts/src/payments/IPaymentManager.sol
+++ b/contracts/src/payments/IPaymentManager.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: UNLICENSE
+pragma solidity >=0.8.13;
+
+/**
+ * @title IPaymentManager
+ * @dev Interface for the PaymentManager contract
+ * @dev This contract is responsible for managing the payments of service
+ * that are made by the users of the blueprint.
+ * @dev The payments are made in the form of tokens, which are transferred
+ * to the Operators whom provide the services.
+ */
+interface IPaymentManager {
+    /**
+     * @dev Get the list of supported tokens
+     * @return address[] List of supported tokens
+     */
+    function supportedTokens() external view returns (address[] memory);
+
+    /**
+     * @dev Add a new token(s) to the list of supported tokens
+     * @param _tokens address[] List of tokens to be added
+     */
+    function addSupportedTokens(address[] memory _tokens) external;
+
+    /**
+     * @dev Remove a token(s) from the list of supported tokens
+     * @param _tokens address[] List of tokens to be removed
+     */
+    function removeSupportedTokens(address[] memory _tokens) external;
+
+    /**
+     * @dev Get the balance of the PaymentManager contract for a specific token
+     * @param _token address Token address
+     * @return uint256 Balance of the PaymentManager contract for the token
+     */
+    function balanceOf(address _token) external view returns (uint256);
+
+    /**
+     * @dev Get the balance of an Operator for a specific token
+     * @param _operator address Operator address
+     * @param _token address Token address
+     * @return uint256 Balance of the Operator for the token
+     */
+    function operatorBalanceOf(address _operator, address _token) external view returns (uint256);
+
+    /**
+     * @dev Credit an Operator with tokens for their services.
+     * @param _operator address Operator address
+     * @param _token address Token address
+     * @param _amount uint256 Amount of tokens to transfer
+     */
+    function creditOperator(address _operator, address _token, uint256 _amount) external;
+
+    /**
+     * @dev Deposit tokens to the PaymentManager contract for a specific token as payment
+     * for the services provided by the Operators (upfront payment)
+     * @param _token address Token address (must be a supported token)
+     * @param _amount uint256 Amount of tokens to pay
+     */
+    function deposit(address _token, uint256 _amount) external payable;
+
+    /**
+     * @dev Withdraw tokens from the PaymentManager contract to the caller
+     * @param _token address Token address
+     * @param _amount uint256 Amount of tokens to withdraw
+     */
+    function withdraw(address _token, uint256 _amount) external;
+
+    /**
+     * @dev Withdraw tokens from the PaymentManager contract to a specific recipient
+     * @param _token address Token address
+     * @param _amount uint256 Amount of tokens to withdraw
+     * @param _recipient address Recipient address
+     */
+    function withdrawAndTransfer(address _token, uint256 _amount, address _recipient) external;
+
+    /**
+     * @dev Get the total amount of tokens required for the service to be provided by the Operators
+     * @param _serviceDuration uint256 Duration of the service in seconds (time)
+     * @param _token address Token address for the payment (must be a supported token)
+     * @return uint256 Total amount of tokens required for the service
+     */
+    function calculateServiceCost(uint256 _serviceDuration, address _token) external view returns (uint256);
+}

--- a/contracts/src/payments/PaymentManagerBase.sol
+++ b/contracts/src/payments/PaymentManagerBase.sol
@@ -1,0 +1,346 @@
+// SPDX-License-Identifier: UNLICENSE
+pragma solidity >=0.8.13;
+
+import "@openzeppelin/contracts/access/AccessControl.sol";
+import "@openzeppelin/contracts/access/extensions/AccessControlEnumerable.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
+import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import "@src/payments/IPaymentManager.sol";
+
+/**
+ * @title PaymentManagerBase
+ * @dev Base contract implementing the IPaymentManager interface with additional functionalities.
+ */
+abstract contract PaymentManagerBase is IPaymentManager, Ownable, AccessControlEnumerable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+    using EnumerableSet for EnumerableSet.AddressSet;
+
+    // Roles
+    bytes32 public constant OPERATOR_ROLE = keccak256("OPERATOR_ROLE");
+    bytes32 public constant SERVICE_OWNER_ROLE = keccak256("SERVICE_OWNER_ROLE");
+    bytes32 public constant ROOT_CHAIN_ROLE = keccak256("ROOT_CHAIN_ROLE");
+
+    EnumerableSet.AddressSet private supportedTokensSet;
+
+    // Operator balances: operator => token => balance
+    mapping(address => mapping(address => uint256)) private operatorBalancesMapping;
+
+    // Service Owners balances: serviceOwner => token => balance
+    mapping(address => mapping(address => uint256)) private serviceOwnerBalancesMapping;
+
+    // Events
+    event TokensAdded(address[] tokens);
+    event TokensRemoved(address[] tokens);
+    event Deposited(address indexed user, address indexed token, uint256 amount);
+    event Withdrawn(address indexed user, address indexed token, uint256 amount);
+    event WithdrawnTo(address indexed user, address indexed token, uint256 amount, address indexed recipient);
+    event OperatorCredited(address indexed operator, address indexed token, uint256 amount);
+
+    // Custom Errors
+    error TokenAlreadySupported(address token);
+    error TokenNotSupported(address token);
+    error InvalidAmount();
+    error Unauthorized();
+    error InsufficientBalance(address token);
+    error TransferFailed();
+    error InvalidRecipient(address recipient);
+    error InvalidETHAmount();
+
+    /**
+     * @dev Constructor sets up roles.
+     */
+    constructor(address initialOwner) Ownable(initialOwner) {
+        _grantRole(DEFAULT_ADMIN_ROLE, initialOwner);
+    }
+
+    /**
+     * @dev Modifier to restrict functions to the root chain.
+     */
+    modifier onlyRootChain() {
+        if (!hasRole(ROOT_CHAIN_ROLE, msg.sender)) {
+            revert Unauthorized();
+        }
+        _;
+    }
+
+    /**
+     * @dev Modifier to restrict functions to service owners.
+     */
+    modifier onlyServiceOwner() {
+        if (!hasRole(SERVICE_OWNER_ROLE, msg.sender)) {
+            revert Unauthorized();
+        }
+        _;
+    }
+
+    /**
+     * @dev Modifier to restrict functions to operators.
+     */
+    modifier onlyOperator() {
+        if (!hasRole(OPERATOR_ROLE, msg.sender)) {
+            revert Unauthorized();
+        }
+        _;
+    }
+
+    /**
+     * @dev Get the list of supported tokens.
+     * @return address[] List of supported tokens
+     */
+    function supportedTokens() public view override returns (address[] memory) {
+        return supportedTokensSet.values();
+    }
+
+    /**
+     * @dev Add new tokens to the list of supported tokens.
+     * @param _tokens List of token addresses to add.
+     */
+    function addSupportedTokens(address[] memory _tokens) public override onlyOwner {
+        uint256 length = _tokens.length;
+        for (uint256 i = 0; i < length; i++) {
+            address token = _tokens[i];
+            bool added = supportedTokensSet.add(token);
+            if (!added) {
+                revert TokenAlreadySupported(token);
+            }
+        }
+        emit TokensAdded(_tokens);
+    }
+
+    /**
+     * @dev Remove tokens from the list of supported tokens.
+     * @param _tokens List of token addresses to remove.
+     */
+    function removeSupportedTokens(address[] memory _tokens) public override onlyOwner {
+        uint256 length = _tokens.length;
+        for (uint256 i = 0; i < length; i++) {
+            address token = _tokens[i];
+            bool removed = supportedTokensSet.remove(token);
+            if (!removed) {
+                revert TokenNotSupported(token);
+            }
+        }
+        emit TokensRemoved(_tokens);
+    }
+
+    /**
+     * @dev Get the balance of the PaymentManager contract for a specific token.
+     * @param _token Token address.
+     * @return Balance of the contract for the token.
+     */
+    function balanceOf(address _token) public view override returns (uint256) {
+        if (_token == address(0)) {
+            return address(this).balance;
+        } else {
+            return IERC20(_token).balanceOf(address(this));
+        }
+    }
+
+    /**
+     * @dev Get the balance of an Operator for a specific token.
+     * @param _operator Operator address.
+     * @param _token Token address.
+     * @return Balance of the operator for the token.
+     */
+    function operatorBalanceOf(address _operator, address _token) public view override returns (uint256) {
+        return operatorBalancesMapping[_operator][_token];
+    }
+
+    /**
+     * @dev Credit an Operator with tokens for their services.
+     * @param _operator Operator address.
+     * @param _token Token address.
+     * @param _amount Amount of tokens to credit.
+     */
+    function creditOperator(address _operator, address _token, uint256 _amount)
+        public
+        override
+        onlyRootChain
+        nonReentrant
+    {
+        if (_amount == 0) {
+            revert InvalidAmount();
+        }
+
+        if (!supportedTokensSet.contains(_token)) {
+            revert TokenNotSupported(_token);
+        }
+
+        if (_token == address(0)) {
+            if (address(this).balance < _amount) {
+                revert InsufficientBalance(_token);
+            }
+            operatorBalancesMapping[_operator][_token] += _amount;
+        } else {
+            uint256 contractBalance = IERC20(_token).balanceOf(address(this));
+            if (contractBalance < _amount + operatorBalancesMapping[_operator][_token]) {
+                revert InsufficientBalance(_token);
+            }
+            operatorBalancesMapping[_operator][_token] += _amount;
+        }
+
+        emit OperatorCredited(_operator, _token, _amount);
+    }
+
+    /**
+     * @dev Deposit tokens or ETH to the PaymentManager contract.
+     * @param _token Token address (address(0) for ETH).
+     * @param _amount Amount to deposit.
+     */
+    function deposit(address _token, uint256 _amount) public payable override nonReentrant {
+        if (_amount == 0) {
+            revert InvalidAmount();
+        }
+
+        if (_token == address(0)) {
+            if (msg.value != _amount) {
+                revert InvalidETHAmount();
+            }
+            emit Deposited(msg.sender, _token, _amount);
+        } else {
+            if (!supportedTokensSet.contains(_token)) {
+                revert TokenNotSupported(_token);
+            }
+            // Check if the contract has enough allowance to transfer the tokens.
+            IERC20(_token).safeTransferFrom(msg.sender, address(this), _amount);
+            emit Deposited(msg.sender, _token, _amount);
+        }
+    }
+
+    /**
+     * @dev Withdraw tokens or ETH to the caller.
+     * @param _token Token address (address(0) for ETH).
+     * @param _amount Amount to withdraw.
+     */
+    function withdraw(address _token, uint256 _amount) public override nonReentrant onlyOperator {
+        _withdraw(_token, _amount, _msgSender());
+    }
+
+    /**
+     * @dev Withdraw tokens or ETH to a specific recipient.
+     * @param _token Token address (address(0) for ETH).
+     * @param _amount Amount to withdraw.
+     * @param _recipient Recipient address.
+     */
+    function withdrawAndTransfer(address _token, uint256 _amount, address _recipient)
+        public
+        override
+        nonReentrant
+        onlyOperator
+    {
+        if (_recipient == address(0)) {
+            revert InvalidRecipient(_recipient);
+        }
+        _withdraw(_token, _amount, _recipient);
+    }
+
+    /**
+     * @dev Internal withdraw function.
+     * @param _token Token address.
+     * @param _amount Amount to withdraw.
+     * @param _recipient Recipient address.
+     */
+    function _withdraw(address _token, uint256 _amount, address _recipient) internal {
+        if (_amount == 0) {
+            revert InvalidAmount();
+        }
+
+        if (_token == address(0)) {
+            _withdrawNative(_amount, _recipient);
+        } else {
+            _withdrawERC20(_token, _amount, _recipient);
+        }
+
+        emit Withdrawn(_recipient, _token, _amount);
+    }
+
+    /**
+     * @dev Internal withdraw function for native tokens.
+     * @param _amount Amount to withdraw.
+     * @param _recipient Recipient address.
+     */
+    function _withdrawNative(uint256 _amount, address _recipient) internal {
+        address _token = address(0);
+        if (_amount == 0) {
+            revert InvalidAmount();
+        }
+
+        // Check if the credit balance is enough to withdraw the requested amount.
+        uint256 creditBalance = operatorBalancesMapping[_msgSender()][_token];
+
+        if (creditBalance < _amount) {
+            revert InsufficientBalance(_token);
+        }
+
+        if (address(this).balance < _amount) {
+            revert InsufficientBalance(_token);
+        }
+
+        Address.sendValue(payable(_recipient), _amount);
+
+        operatorBalancesMapping[_msgSender()][_token] -= _amount;
+    }
+
+    /**
+     * @dev Internal withdraw function for non-native tokens.
+     * @param _token Token address.
+     * @param _amount Amount to withdraw.
+     * @param _recipient Recipient address.
+     */
+    function _withdrawERC20(address _token, uint256 _amount, address _recipient) internal {
+        if (_amount == 0) {
+            revert InvalidAmount();
+        }
+
+        if (!supportedTokensSet.contains(_token)) {
+            revert TokenNotSupported(_token);
+        }
+
+        // Check if the credit balance is enough to withdraw the requested amount.
+        uint256 creditBalance = operatorBalancesMapping[_msgSender()][_token];
+
+        if (creditBalance < _amount) {
+            revert InsufficientBalance(_token);
+        }
+
+        uint256 contractBalance = IERC20(_token).balanceOf(address(this));
+        if (contractBalance < _amount) {
+            revert InsufficientBalance(_token);
+        }
+
+        IERC20(_token).safeTransfer(_recipient, _amount);
+        // Deduct the withdrawn amount from the credit balance.
+        operatorBalancesMapping[_msgSender()][_token] -= _amount;
+    }
+
+    /**
+     * @dev Fallback function to prevent accidental ETH transfers.
+     */
+    fallback() external payable {
+        revert TransferFailed();
+    }
+
+    /**
+     * @dev Receive function to prevent accidental ETH transfers.
+     */
+    receive() external payable {
+        revert TransferFailed();
+    }
+
+    /**
+     * @dev Calculate service cost - to be implemented by inheriting contracts.
+     * @param _serviceDuration Duration of the service in seconds.
+     * @param _token Token address.
+     * @return Total cost of the service.
+     */
+    function calculateServiceCost(uint256 _serviceDuration, address _token)
+        external
+        view
+        virtual
+        override
+        returns (uint256);
+}

--- a/contracts/src/payments/PaymentManagerBase.sol
+++ b/contracts/src/payments/PaymentManagerBase.sol
@@ -9,7 +9,7 @@ import "@openzeppelin/contracts/utils/Address.sol";
 import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
-import "@src/payments/IPaymentManager.sol";
+import "./IPaymentManager.sol";
 
 /**
  * @title PaymentManagerBase

--- a/contracts/test/FrostBlueprint.t.sol
+++ b/contracts/test/FrostBlueprint.t.sol
@@ -211,10 +211,9 @@ contract FrostBlueprintTest is Test {
         // Prepare inputs and outputs for keygen job
         uint16 threshold = 1;
         bytes memory inputs = abi.encodePacked(threshold);
-        bytes memory validPublicKey = new bytes(33); // Valid ECDSA public key length
-        validPublicKey[0] = 0x02; // Compressed public key prefix
+        bytes memory validPublicKey = new bytes(32); // Valid ECDSA public key length
         // Fill the rest with dummy data
-        for (uint256 i = 1; i < 33; i++) {
+        for (uint256 i = 1; i < 32; i++) {
             validPublicKey[i] = bytes1(uint8(i));
         }
         bytes memory outputs = abi.encodePacked(validPublicKey);
@@ -305,40 +304,13 @@ contract FrostBlueprintTest is Test {
         vm.prank(rootChain);
         frostBlueprint.onRequest(serviceId, operators, "");
 
-        // Prepare invalid outputs for keygen job (length != 33)
-        bytes memory outputs = new bytes(32); // Invalid length
+        // Prepare invalid outputs for keygen job (length != 32)
+        bytes memory outputs = new bytes(33); // Invalid length
 
         // Simulate rootChain calling onJobResult
         vm.prank(rootChain);
         vm.expectRevert(abi.encodeWithSelector(FrostBlueprint.InvalidECDSAPublicKey.selector));
         frostBlueprint.onJobResult(serviceId, KEYGEN_JOB_ID, 1, operatorPublicKey, "", outputs);
-    }
-
-    // Test handling invalid ECDSA signature
-    function testHandleInvalidECDSASignature() public {
-        // Register operator1
-        vm.prank(rootChain);
-        frostBlueprint.onRegister(operator1PublicKey, "");
-
-        uint64 serviceId = 1;
-
-        // Add operator1 to serviceId
-        bytes[] memory operators = new bytes[](1);
-        operators[0] = operator1PublicKey;
-        vm.prank(rootChain);
-        frostBlueprint.onRequest(serviceId, operators, "");
-
-        // Prepare inputs and outputs for sign job with invalid signature length
-        bytes memory publicKey = operator2PublicKey;
-        bytes memory message = "Test Message";
-        bytes memory inputs = abi.encode(publicKey, message);
-        bytes memory invalidSignature = new bytes(64); // Invalid length
-        bytes memory outputs = invalidSignature;
-
-        // Simulate rootChain calling onJobResult
-        vm.prank(rootChain);
-        vm.expectRevert(abi.encodeWithSelector(FrostBlueprint.InvalidECDSASignature.selector));
-        frostBlueprint.onJobResult(serviceId, SIGN_JOB_ID, 1, operator1PublicKey, inputs, outputs);
     }
 
     // Test calculateServiceCost

--- a/contracts/test/FrostBlueprint.t.sol
+++ b/contracts/test/FrostBlueprint.t.sol
@@ -1,20 +1,699 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.7.0 <0.9.0;
 
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {Test} from "forge-std/Test.sol";
+import {console2} from "forge-std/console2.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@src/FrostBlueprint.sol";
+
+contract ERC20Mock is ERC20, Ownable {
+    constructor(string memory name, string memory symbol, uint8 decimals, address owner, uint256 initialSupply)
+        Ownable(owner)
+        ERC20(name, symbol)
+    {
+        mint(owner, initialSupply * (10 ** uint256(decimals)));
+    }
+
+    function mint(address to, uint256 value) public virtual {
+        _mint(to, value);
+    }
+
+    function burn(address from, uint256 value) public virtual {
+        _burn(from, value);
+    }
+}
 
 contract FrostBlueprintTest is Test {
-    uint256 testNumber;
+    // Instance of the FrostBlueprint contract
+    FrostBlueprint public frostBlueprint;
 
+    // Mock ERC20 token
+    ERC20Mock public mockERC20;
+
+    // Address variables for different roles
+    address public owner;
+    address public rootChain;
+    bytes public operator1PublicKey;
+    bytes public operator2PublicKey;
+    address public operator1;
+    address public operator2;
+    address public serviceOwner;
+    address public nonAuthorized;
+
+    // Constants
+    address constant TNT_ERC20_ADDRESS = address(0x0000000000000000000000000000000000000802);
+
+    bytes32 public constant DEFAULT_ADMIN_ROLE = 0x00;
+    uint8 constant KEYGEN_JOB_ID = 0;
+    uint8 constant SIGN_JOB_ID = 1;
+
+    // Setup function runs before each test
     function setUp() public {
-        testNumber = 42;
+        // Assign test addresses
+        owner = address(0x1);
+        rootChain = address(0x2);
+        operator1PublicKey = hex"14463bfb5433001c187e7a28c480d3945db9279ba4ef96f29c5e0e565f56b254d5";
+        operator2PublicKey = hex"7f316ac29a1c2a5e6e5c8cff51b225af088b5066e569c73ba6eba896a07c560f54";
+        operator1 = operatorAddress(operator1PublicKey);
+        operator2 = operatorAddress(operator2PublicKey);
+        serviceOwner = address(0x5);
+        nonAuthorized = address(0x6);
+
+        // Deploy mock ERC20 token
+        mockERC20 = new ERC20Mock("Tangle", "TNT", 18, owner, 1e24); // 1 million tokens
+        bytes memory code = address(mockERC20).code;
+        vm.etch(TNT_ERC20_ADDRESS, code);
+        mockERC20 = ERC20Mock(TNT_ERC20_ADDRESS);
+        mockERC20.mint(owner, 1e24); // Mint 1 million tokens to owner
+
+        // Deploy FrostBlueprint contract with owner as the deployer
+        vm.startPrank(owner);
+        frostBlueprint = new FrostBlueprint();
+        rootChain = frostBlueprint.ROOT_CHAIN();
+        assertEq(frostBlueprint.owner(), owner);
+        vm.stopPrank();
     }
 
-    function test_NumberIs42() public view {
-        assertEq(testNumber, 42);
+    // Helper function to convert a public key to an operator address
+    function operatorAddress(bytes memory publicKey) internal pure returns (address) {
+        return address(uint160(uint256(keccak256(publicKey))));
     }
 
-    function testFail_Subtract43() public {
-        testNumber -= 43;
+    // Test deployment and initial configuration
+    function testDeployment() public {
+        // Check that the owner has DEFAULT_ADMIN_ROLE
+        assertTrue(frostBlueprint.hasRole(DEFAULT_ADMIN_ROLE, owner));
+
+        // Check that rootChain has ROOT_CHAIN_ROLE and DEFAULT_ADMIN_ROLE
+        assertTrue(frostBlueprint.hasRole(frostBlueprint.ROOT_CHAIN_ROLE(), rootChain));
+        assertTrue(frostBlueprint.hasRole(DEFAULT_ADMIN_ROLE, rootChain));
+
+        // Check that TNT_ERC20_ADDRESS is supported by default
+        address[] memory supportedTokens = frostBlueprint.supportedTokens();
+        bool tokenSupported = false;
+        for (uint256 i = 0; i < supportedTokens.length; i++) {
+            if (supportedTokens[i] == TNT_ERC20_ADDRESS) {
+                tokenSupported = true;
+                break;
+            }
+        }
+        assertTrue(tokenSupported, "TNT_ERC20_ADDRESS should be supported by default");
+
+        // Check initial job costs
+        // Assuming mockERC20 is deployed at TNT_ERC20_ADDRESS
+        // Verify keygen job cost
+        uint256 keygenCost = frostBlueprint.jobCost(KEYGEN_JOB_ID, TNT_ERC20_ADDRESS);
+        assertEq(keygenCost, 1e15, "Keygen job cost should be 0.001 ether");
+
+        // Verify sign job cost
+        uint256 signCost = frostBlueprint.jobCost(SIGN_JOB_ID, TNT_ERC20_ADDRESS);
+        assertEq(signCost, 1e13, "Sign job cost should be 0.00001 ether");
+    }
+
+    // Test operator registration
+    function testOperatorRegistration() public {
+        bytes memory operatorPublicKey = abi.encodePacked(operator1);
+        // Simulate rootChain calling onRegister
+        vm.prank(rootChain);
+        frostBlueprint.onRegister(operatorPublicKey, "");
+
+        // Verify that operator1 has OPERATOR_ROLE
+        address expectedOperator = frostBlueprint.operatorAddressFromPublicKey(operatorPublicKey);
+        assertTrue(
+            frostBlueprint.hasRole(frostBlueprint.OPERATOR_ROLE(), expectedOperator),
+            "Operator should have OPERATOR_ROLE"
+        );
+
+        // Emit and verify OperatorRegistered event
+        // Note: Events are not directly captured in Forge tests, but can be verified via other means if necessary
+    }
+
+    // Test operator registration by non-rootChain should fail
+    function testOperatorRegistrationUnauthorized() public {
+        bytes memory operatorPublicKey = abi.encodePacked(operator1);
+
+        // Attempt to register operator1 from non-rootChain address
+        vm.prank(nonAuthorized);
+        vm.expectRevert("Unauthorized");
+        frostBlueprint.onRegister(operatorPublicKey, "");
+    }
+
+    // Test adding service operators
+    function testAddServiceOperator() public {
+        // First, register operator1
+        bytes memory operatorPublicKey = abi.encodePacked(operator1);
+        vm.prank(rootChain);
+        frostBlueprint.onRegister(operatorPublicKey, "");
+
+        uint64 serviceId = 1;
+
+        // Simulate rootChain calling onRequest to add operator1 to serviceId
+        bytes[] memory operators = new bytes[](1);
+        operators[0] = operatorPublicKey;
+        vm.prank(rootChain);
+        frostBlueprint.onRequest(serviceId, operators, "");
+
+        // Verify that operator1 is added to the service
+        address[] memory serviceOperators = frostBlueprint.serviceOperators(serviceId);
+        assertEq(serviceOperators.length, 1, "Service should have 1 operator");
+
+        assertTrue(serviceOperators[0] == operatorAddress(operatorPublicKey), "Operator1 should be added to service");
+    }
+
+    // Test adding the same operator twice should revert
+    function testAddServiceOperatorTwice() public {
+        // Register operator1
+        vm.prank(rootChain);
+        frostBlueprint.onRegister(operator1PublicKey, "");
+
+        uint64 serviceId = 1;
+
+        bytes[] memory operators = new bytes[](1);
+        operators[0] = operator1PublicKey;
+
+        // Add operator1 to serviceId
+        vm.prank(rootChain);
+        frostBlueprint.onRequest(serviceId, operators, "");
+
+        // Attempt to add operator1 again to the same service
+        vm.prank(rootChain);
+        vm.expectRevert(abi.encodeWithSelector(FrostBlueprint.OperatorAlreadyAdded.selector, serviceId, operator1));
+        frostBlueprint.onRequest(serviceId, operators, "");
+    }
+
+    // Test adding unregistered operator should revert
+    function testAddUnregisteredServiceOperator() public {
+        uint64 serviceId = 1;
+
+        bytes[] memory operators = new bytes[](1);
+        bytes memory unregisteredOperatorPK = abi.encodePacked(operator2);
+        operators[0] = unregisteredOperatorPK;
+
+        // Attempt to add unregistered operator2 to serviceId
+        vm.prank(rootChain);
+        vm.expectRevert(abi.encodeWithSelector(FrostBlueprint.OperatorNotRegistered.selector, operator2));
+        frostBlueprint.onRequest(serviceId, operators, "");
+    }
+
+    // Test handling keygen job result
+    function testHandleKeygenJobResult() public {
+        // Register operator1
+        bytes memory operatorPublicKey = abi.encodePacked(operator1);
+        vm.prank(rootChain);
+        frostBlueprint.onRegister(operatorPublicKey, "");
+
+        uint64 serviceId = 1;
+
+        // Add operator1 to serviceId
+        bytes[] memory operators = new bytes[](1);
+        operators[0] = operatorPublicKey;
+        vm.prank(rootChain);
+        frostBlueprint.onRequest(serviceId, operators, "");
+
+        // Prepare inputs and outputs for keygen job
+        bytes memory inputs = ""; // Assuming no inputs needed
+        bytes memory validPublicKey = new bytes(33); // Valid ECDSA public key length
+        validPublicKey[0] = 0x04; // Uncompressed key prefix
+        // Fill the rest with dummy data
+        for (uint256 i = 1; i < 33; i++) {
+            validPublicKey[i] = bytes1(uint8(i));
+        }
+        bytes memory outputs = validPublicKey;
+
+        // Mock the supportedTokens to include mockERC20
+        // Since the constructor adds TNT_ERC20_ADDRESS, ensure it's the mockERC20 address
+        // For simplicity, assume mockERC20 is at TNT_ERC20_ADDRESS
+
+        // Assign mockERC20 balance to FrostBlueprint
+        // Transfer tokens from owner to FrostBlueprint
+        vm.prank(owner);
+        mockERC20.transfer(address(frostBlueprint), 1e18); // 1 token
+
+        // Simulate rootChain calling onJobResult
+        vm.prank(rootChain);
+        frostBlueprint.onJobResult(serviceId, KEYGEN_JOB_ID, 1, operatorPublicKey, inputs, outputs);
+
+        // Verify that operator1 has been credited
+        uint256 expectedAmount = 1e15 * 5 * 1; // tokensPerSec * duration * operatorsCount
+        uint256 actualBalance = frostBlueprint.operatorBalanceOf(operator1, TNT_ERC20_ADDRESS);
+        assertEq(actualBalance, expectedAmount, "Operator1 should be credited correctly");
+    }
+
+    // Test handling sign job result
+    function testHandleSignJobResult() public {
+        // Register operator1
+        bytes memory operatorPublicKey = abi.encodePacked(operator1);
+        vm.prank(rootChain);
+        frostBlueprint.onRegister(operatorPublicKey, "");
+
+        uint64 serviceId = 1;
+
+        // Add operator1 to serviceId
+        bytes[] memory operators = new bytes[](1);
+        operators[0] = operatorPublicKey;
+        vm.prank(rootChain);
+        frostBlueprint.onRequest(serviceId, operators, "");
+
+        // Prepare inputs and outputs for sign job
+        bytes memory publicKey = abi.encodePacked(operator1);
+        bytes memory message = "Test Message";
+        bytes memory inputs = abi.encode(publicKey, message);
+        bytes memory signature = new bytes(65); // Valid ECDSA signature length
+        // Fill with dummy data
+        for (uint256 i = 0; i < 65; i++) {
+            signature[i] = bytes1(uint8(i));
+        }
+        bytes memory outputs = signature;
+
+        // Assign mockERC20 balance to FrostBlueprint
+        vm.prank(owner);
+        mockERC20.transfer(address(frostBlueprint), 1e18); // 1 token
+
+        // Simulate rootChain calling onJobResult
+        vm.prank(rootChain);
+        frostBlueprint.onJobResult(serviceId, SIGN_JOB_ID, 1, operatorPublicKey, inputs, outputs);
+
+        // Verify that operator1 has been credited
+        uint256 expectedAmount = 1e13 * 3; // tokensPerSec * duration
+        uint256 actualBalance = frostBlueprint.operatorBalanceOf(operator1, TNT_ERC20_ADDRESS);
+        assertEq(actualBalance, expectedAmount, "Operator1 should be credited correctly for sign job");
+    }
+
+    // Test handling unsupported job
+    function testHandleUnsupportedJob() public {
+        uint64 serviceId = 1;
+        uint8 unsupportedJobId = 2;
+
+        bytes memory operatorPublicKey = abi.encodePacked(operator1);
+
+        // Simulate rootChain calling onJobResult with unsupported job
+        vm.prank(rootChain);
+        vm.expectRevert(abi.encodeWithSelector(FrostBlueprint.UnsupportedJob.selector, unsupportedJobId));
+        frostBlueprint.onJobResult(serviceId, unsupportedJobId, 1, operatorPublicKey, "", "");
+    }
+
+    // Test handling invalid ECDSA public key
+    function testHandleInvalidECDSAPublicKey() public {
+        // Register operator1
+        bytes memory operatorPublicKey = abi.encodePacked(operator1);
+        vm.prank(rootChain);
+        frostBlueprint.onRegister(operatorPublicKey, "");
+
+        uint64 serviceId = 1;
+
+        // Add operator1 to serviceId
+        bytes[] memory operators = new bytes[](1);
+        operators[0] = operatorPublicKey;
+        vm.prank(rootChain);
+        frostBlueprint.onRequest(serviceId, operators, "");
+
+        // Prepare invalid outputs for keygen job (length != 33)
+        bytes memory outputs = new bytes(32); // Invalid length
+
+        // Simulate rootChain calling onJobResult
+        vm.prank(rootChain);
+        vm.expectRevert(abi.encodeWithSelector(FrostBlueprint.InvalidECDSAPublicKey.selector, outputs));
+        frostBlueprint.onJobResult(serviceId, KEYGEN_JOB_ID, 1, operatorPublicKey, "", outputs);
+    }
+
+    // Test handling invalid ECDSA signature
+    function testHandleInvalidECDSASignature() public {
+        // Register operator1
+        bytes memory operatorPublicKey = abi.encodePacked(operator1);
+        vm.prank(rootChain);
+        frostBlueprint.onRegister(operatorPublicKey, "");
+
+        uint64 serviceId = 1;
+
+        // Add operator1 to serviceId
+        bytes[] memory operators = new bytes[](1);
+        operators[0] = operatorPublicKey;
+        vm.prank(rootChain);
+        frostBlueprint.onRequest(serviceId, operators, "");
+
+        // Prepare inputs and outputs for sign job with invalid signature length
+        bytes memory publicKey = abi.encodePacked(operator1);
+        bytes memory message = "Test Message";
+        bytes memory inputs = abi.encode(publicKey, message);
+        bytes memory invalidSignature = new bytes(64); // Invalid length
+        bytes memory outputs = invalidSignature;
+
+        // Simulate rootChain calling onJobResult
+        vm.prank(rootChain);
+        vm.expectRevert(abi.encodeWithSelector(FrostBlueprint.InvalidECDSASignature.selector, invalidSignature));
+        frostBlueprint.onJobResult(serviceId, SIGN_JOB_ID, 1, operatorPublicKey, inputs, outputs);
+    }
+
+    // Test calculateServiceCost
+    function testCalculateServiceCost() public {
+        uint256 serviceDuration = 10; // seconds
+
+        // Calculate expected cost
+        uint256 oneKeygenCall = 1e15; // as set in deployment
+        uint256 oneSignCall = 1e13;
+        uint256 expectedCostPerSec = oneKeygenCall + oneSignCall;
+        uint256 expectedTotalCost = expectedCostPerSec * serviceDuration;
+
+        uint256 actualCost = frostBlueprint.calculateServiceCost(serviceDuration, TNT_ERC20_ADDRESS);
+        assertEq(actualCost, expectedTotalCost, "Service cost should be calculated correctly");
+    }
+
+    // Test updateJobCost
+    function testUpdateJobCost() public {
+        // New costs
+        uint256 newKeygenCost = 2e15; // 0.002 ether
+        uint256 newSignCost = 2e13; // 0.00002 ether
+
+        // Update keygen job cost
+        vm.prank(owner);
+        frostBlueprint.updateJobCost(KEYGEN_JOB_ID, TNT_ERC20_ADDRESS, newKeygenCost);
+
+        // Update sign job cost
+        vm.prank(owner);
+        frostBlueprint.updateJobCost(SIGN_JOB_ID, TNT_ERC20_ADDRESS, newSignCost);
+
+        // Verify updates
+        uint256 updatedKeygenCost = frostBlueprint.jobCost(KEYGEN_JOB_ID, TNT_ERC20_ADDRESS);
+        assertEq(updatedKeygenCost, newKeygenCost, "Keygen job cost should be updated");
+
+        uint256 updatedSignCost = frostBlueprint.jobCost(SIGN_JOB_ID, TNT_ERC20_ADDRESS);
+        assertEq(updatedSignCost, newSignCost, "Sign job cost should be updated");
+    }
+
+    // Test updateJobCost with unsupported job ID
+    function testUpdateJobCostUnsupportedJob() public {
+        uint8 unsupportedJobId = 2;
+        uint256 newCost = 1e12;
+
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(FrostBlueprint.UnsupportedJob.selector, unsupportedJobId));
+        frostBlueprint.updateJobCost(unsupportedJobId, TNT_ERC20_ADDRESS, newCost);
+    }
+
+    // Test adding supported tokens
+    function testAddSupportedTokens() public {
+        // Deploy a new mock token
+        ERC20Mock newMockToken = new ERC20Mock("New Mock Token", "NMTKN", 18, owner, 1e24);
+
+        address[] memory tokensToAdd = new address[](1);
+        tokensToAdd[0] = address(newMockToken);
+
+        vm.prank(owner);
+        frostBlueprint.addSupportedTokens(tokensToAdd);
+
+        // Verify the token is added
+        address[] memory supportedTokens = frostBlueprint.supportedTokens();
+        bool tokenAdded = false;
+        for (uint256 i = 0; i < supportedTokens.length; i++) {
+            if (supportedTokens[i] == address(newMockToken)) {
+                tokenAdded = true;
+                break;
+            }
+        }
+        assertTrue(tokenAdded, "New mock token should be added to supported tokens");
+    }
+
+    // Test adding already supported token should revert
+    function testAddAlreadySupportedToken() public {
+        address[] memory tokensToAdd = new address[](1);
+        tokensToAdd[0] = TNT_ERC20_ADDRESS;
+
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(PaymentManagerBase.TokenAlreadySupported.selector, TNT_ERC20_ADDRESS));
+        frostBlueprint.addSupportedTokens(tokensToAdd);
+    }
+
+    // Test removing supported tokens
+    function testRemoveSupportedTokens() public {
+        address[] memory tokensToRemove = new address[](1);
+        tokensToRemove[0] = TNT_ERC20_ADDRESS;
+
+        vm.prank(owner);
+        frostBlueprint.removeSupportedTokens(tokensToRemove);
+
+        // Verify the token is removed
+        address[] memory supportedTokens = frostBlueprint.supportedTokens();
+        bool tokenRemoved = true;
+        for (uint256 i = 0; i < supportedTokens.length; i++) {
+            if (supportedTokens[i] == TNT_ERC20_ADDRESS) {
+                tokenRemoved = false;
+                break;
+            }
+        }
+        assertTrue(tokenRemoved, "TNT_ERC20_ADDRESS should be removed from supported tokens");
+    }
+
+    // Test removing a token that is not supported should revert
+    function testRemoveUnsupportedToken() public {
+        // Deploy a new mock token
+        ERC20Mock newMockToken = new ERC20Mock("New Mock Token", "NMTKN", 18, owner, 1e24);
+
+        address[] memory tokensToRemove = new address[](1);
+        tokensToRemove[0] = address(newMockToken);
+
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(PaymentManagerBase.TokenNotSupported.selector, address(newMockToken)));
+        frostBlueprint.removeSupportedTokens(tokensToRemove);
+    }
+
+    // Test deposit tokens by service owner
+    function testDepositTokens() public {
+        uint256 depositAmount = 1e18; // 1 token
+
+        // Deploy a new mock token and add to supported tokens
+        ERC20Mock newMockToken = new ERC20Mock("New Mock Token", "NMTKN", 18, owner, 1e24);
+        address[] memory tokensToAdd = new address[](1);
+        tokensToAdd[0] = address(newMockToken);
+        vm.prank(owner);
+        frostBlueprint.addSupportedTokens(tokensToAdd);
+
+        // Approve FrostBlueprint to spend tokens
+        vm.prank(serviceOwner);
+        newMockToken.approve(address(frostBlueprint), depositAmount);
+
+        // Simulate serviceOwner depositing tokens
+        vm.prank(serviceOwner);
+        frostBlueprint.deposit(address(newMockToken), depositAmount);
+
+        // Verify Deposit event (optional)
+
+        // Verify the contract's balance
+        uint256 contractBalance = newMockToken.balanceOf(address(frostBlueprint));
+        assertEq(contractBalance, depositAmount, "FrostBlueprint should have the deposited tokens");
+    }
+
+    // Test deposit ETH by service owner
+    function testDepositETH() public {
+        uint256 depositAmount = 1 ether;
+
+        // Simulate serviceOwner depositing ETH
+        vm.deal(serviceOwner, depositAmount);
+        vm.prank(serviceOwner);
+        frostBlueprint.deposit{value: depositAmount}(address(0), depositAmount);
+
+        // Verify the contract's ETH balance
+        uint256 contractBalance = address(frostBlueprint).balance;
+        assertEq(contractBalance, depositAmount, "FrostBlueprint should have the deposited ETH");
+    }
+
+    // Test deposit with invalid amount should revert
+    function testDepositInvalidAmount() public {
+        uint256 depositAmount = 0;
+
+        // Attempt to deposit with amount 0
+        vm.prank(serviceOwner);
+        vm.expectRevert("InvalidAmount()");
+        frostBlueprint.deposit(address(0), depositAmount);
+    }
+
+    // Test withdraw tokens by operator
+    function testWithdrawTokens() public {
+        uint256 depositAmount = 1e18; // 1 token
+        uint256 withdrawAmount = 0.0005 ether; // 0.0005 ether (less than keygen job cost)
+
+        // Register operator1 and credit
+        vm.prank(rootChain);
+        frostBlueprint.onRegister(operator1PublicKey, "");
+
+        uint256 balance = mockERC20.balanceOf(owner);
+        // Transfer some tokens from owner to blueprint manager by depositing
+        vm.prank(owner);
+        // Approve FrostBlueprint to spend tokens
+        mockERC20.approve(address(frostBlueprint), balance);
+        vm.prank(owner);
+        frostBlueprint.deposit(TNT_ERC20_ADDRESS, depositAmount);
+
+        // Credit operator1
+        vm.prank(rootChain);
+        frostBlueprint.creditOperator(operator1, TNT_ERC20_ADDRESS, withdrawAmount);
+
+        // Record initial balance of operator1
+        uint256 initialBalance = mockERC20.balanceOf(operator1);
+
+        // Simulate operator1 withdrawing tokens
+        vm.prank(operator1);
+        frostBlueprint.withdraw(TNT_ERC20_ADDRESS, withdrawAmount);
+
+        // Verify operator1 received tokens
+        uint256 finalBalance = mockERC20.balanceOf(operator1);
+        assertEq(finalBalance, initialBalance + withdrawAmount, "Operator1 should receive withdrawn tokens");
+
+        // Verify operator's balance in FrostBlueprint
+        uint256 operatorBalance = frostBlueprint.operatorBalanceOf(operator1, TNT_ERC20_ADDRESS);
+        assertEq(operatorBalance, 0, "Operator1's balance should be zero after withdrawal");
+    }
+
+    // Test withdraw ETH by operator
+    function testWithdrawETH() public {
+        uint256 depositAmount = 1 ether;
+        uint256 withdrawAmount = 5 ether;
+
+        // Credit operator1 with ETH (assuming contract has enough balance)
+        // For testing, fund the contract with ETH
+        vm.deal(owner, withdrawAmount);
+        vm.deal(address(frostBlueprint), withdrawAmount);
+
+        // Add Support for name tokens
+        vm.prank(owner);
+        address[] memory supportedTokens = new address[](1);
+        supportedTokens[0] = address(0);
+        frostBlueprint.addSupportedTokens(supportedTokens);
+
+        // Register operator1 and credit
+        vm.prank(rootChain);
+        frostBlueprint.onRegister(operator1PublicKey, "");
+
+        // Credit operator1
+        vm.prank(rootChain);
+        frostBlueprint.creditOperator(operator1, address(0), withdrawAmount);
+
+        // Record initial ETH balance of operator1
+        uint256 initialBalance = operator1.balance;
+
+        // Simulate operator1 withdrawing ETH
+        vm.prank(operator1);
+        frostBlueprint.withdraw(address(0), withdrawAmount);
+
+        // Verify operator1 received ETH
+        uint256 finalBalance = operator1.balance;
+        assertEq(finalBalance, initialBalance + withdrawAmount, "Operator1 should receive withdrawn ETH");
+
+        // Verify operator's ETH balance in FrostBlueprint
+        uint256 operatorETHBalance = frostBlueprint.operatorBalanceOf(operator1, address(0));
+        assertEq(operatorETHBalance, 0, "Operator1's ETH balance should be zero after withdrawal");
+    }
+
+    // Test withdraw with insufficient balance should revert
+    function testWithdrawInsufficientBalance() public {
+        uint256 withdrawAmount = 1e18; // 1 token
+
+        // Register operator1
+        bytes memory operatorPublicKey = abi.encodePacked(operator1);
+        vm.prank(rootChain);
+        frostBlueprint.onRegister(operatorPublicKey, "");
+
+        // Attempt to withdraw without crediting
+        vm.prank(operator1);
+        vm.expectRevert(abi.encodeWithSelector(PaymentManagerBase.InsufficientBalance.selector, TNT_ERC20_ADDRESS));
+        frostBlueprint.withdraw(TNT_ERC20_ADDRESS, withdrawAmount);
+    }
+
+    // Test withdraw to a specific recipient
+    function testWithdrawAndTransfer() public {
+        uint256 depositAmount = 1e18; // 1 token
+        uint256 withdrawAmount = 5e14; // 0.0005 ether
+
+        // Register operator1 and credit
+        bytes memory operatorPublicKey = abi.encodePacked(operator1);
+        vm.prank(rootChain);
+        frostBlueprint.onRegister(operatorPublicKey, "");
+
+        vm.prank(rootChain);
+        frostBlueprint.creditOperator(operator1, TNT_ERC20_ADDRESS, withdrawAmount);
+
+        // Record initial balance of nonAuthorized
+        uint256 initialBalance = mockERC20.balanceOf(nonAuthorized);
+
+        // Simulate operator1 withdrawing to nonAuthorized
+        vm.prank(operator1);
+        frostBlueprint.withdrawAndTransfer(TNT_ERC20_ADDRESS, withdrawAmount, nonAuthorized);
+
+        // Verify nonAuthorized received tokens
+        uint256 finalBalance = mockERC20.balanceOf(nonAuthorized);
+        assertEq(finalBalance, initialBalance + withdrawAmount, "nonAuthorized should receive withdrawn tokens");
+
+        // Verify operator's balance in FrostBlueprint
+        uint256 operatorBalance = frostBlueprint.operatorBalanceOf(operator1, TNT_ERC20_ADDRESS);
+        assertEq(operatorBalance, 0, "Operator1's balance should be zero after withdrawal");
+    }
+
+    // Test withdrawAndTransfer with invalid recipient should revert
+    function testWithdrawAndTransferInvalidRecipient() public {
+        uint256 withdrawAmount = 1e18; // 1 token
+
+        // Register operator1 and credit
+        bytes memory operatorPublicKey = abi.encodePacked(operator1);
+        vm.prank(rootChain);
+        frostBlueprint.onRegister(operatorPublicKey, "");
+
+        vm.prank(rootChain);
+        frostBlueprint.creditOperator(operator1, TNT_ERC20_ADDRESS, withdrawAmount);
+
+        // Attempt to withdraw to address(0)
+        vm.prank(operator1);
+        vm.expectRevert(abi.encodeWithSelector(PaymentManagerBase.InvalidRecipient.selector, address(0)));
+        frostBlueprint.withdrawAndTransfer(TNT_ERC20_ADDRESS, withdrawAmount, address(0));
+    }
+
+    // Test deposit ETH with incorrect msg.value should revert
+    function testDepositETHIncorrectValue() public {
+        uint256 depositAmount = 1 ether;
+        uint256 sentValue = 2 ether;
+
+        // Attempt to deposit ETH with incorrect msg.value
+        vm.prank(serviceOwner);
+        vm.expectRevert(abi.encodeWithSelector(PaymentManagerBase.InvalidETHAmount.selector));
+        frostBlueprint.deposit{value: sentValue}(address(0), depositAmount);
+    }
+
+    // Test deposit unsupported token should revert
+    function testDepositUnsupportedToken() public {
+        // Deploy a new mock token but do not add to supported tokens
+        ERC20Mock newMockToken = new ERC20Mock("Unsupported Token", "USTKN", 18, owner, 1e24);
+
+        uint256 depositAmount = 1e18; // 1 token
+
+        // Approve FrostBlueprint to spend tokens
+        vm.prank(serviceOwner);
+        newMockToken.approve(address(frostBlueprint), depositAmount);
+
+        // Attempt to deposit unsupported token
+        vm.prank(serviceOwner);
+        vm.expectRevert(abi.encodeWithSelector(PaymentManagerBase.TokenNotSupported.selector, address(newMockToken)));
+        frostBlueprint.deposit(address(newMockToken), depositAmount);
+    }
+
+    // Test withdraw unsupported token should revert
+    function testWithdrawUnsupportedToken() public {
+        // Deploy a new mock token but do not add to supported tokens
+        ERC20Mock newMockToken = new ERC20Mock("Unsupported Token", "USTKN", 18, owner, 1e24);
+
+        uint256 withdrawAmount = 1e18; // 1 token
+
+        // Attempt to withdraw unsupported token
+        vm.prank(operator1);
+        vm.expectRevert(abi.encodeWithSelector(PaymentManagerBase.TokenNotSupported.selector, address(newMockToken)));
+        frostBlueprint.withdraw(address(newMockToken), withdrawAmount);
+    }
+
+    // Test unauthorized withdrawal should revert
+    function testUnauthorizedWithdrawal() public {
+        uint256 withdrawAmount = 1e18; // 1 token
+
+        // Attempt to withdraw as non-operator
+        vm.prank(nonAuthorized);
+        vm.expectRevert("Unauthorized");
+        frostBlueprint.withdraw(TNT_ERC20_ADDRESS, withdrawAmount);
     }
 }

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,4 +1,3 @@
 @openzeppelin/contracts/=dependencies/@openzeppelin-contracts-5.1.0/
 forge-std/=dependencies/forge-std-1.9.4/src/
 tnt-core/=dependencies/tnt-core-0.1.0/src/
-@src/=contracts/src/

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,3 +1,4 @@
-@openzeppelin-contracts/=dependencies/@openzeppelin-contracts-5.1.0/
+@openzeppelin/contracts/=dependencies/@openzeppelin-contracts-5.1.0/
 forge-std/=dependencies/forge-std-1.9.4/src/
 tnt-core/=dependencies/tnt-core-0.1.0/src/
+@src/=contracts/src/

--- a/src/keygen.rs
+++ b/src/keygen.rs
@@ -186,8 +186,7 @@ where
     Ok(verifying_key)
 }
 
-// #[cfg(all(test, feature = "e2e"))]
-#[cfg(test)]
+#[cfg(all(test, feature = "e2e"))]
 mod e2e {
     use alloy_primitives::U256;
     use alloy_sol_types::sol;
@@ -224,8 +223,8 @@ mod e2e {
 
     sol!(
         #[sol(rpc)]
-        IERC20,
-        "contracts/out/ERC20/IERC20.sol/IERC20.json",
+        ERC20,
+        "contracts/out/ERC20.sol/ERC20.json"
     );
 
     #[tokio::test(flavor = "multi_thread")]
@@ -292,10 +291,10 @@ mod e2e {
                     .await
                     .map(|t| t.TNT_ERC20_ADDRESS)
                     .unwrap();
-                let tnt_token = IERC20::new(tnt_token_address, provider.clone());
+                let tnt_token = ERC20::new(tnt_token_address, provider.clone());
 
                 // Send Some TNT to the Blueprint manager contract.
-                let tx = tnt_token.transfer(blueprint_manager, value.into());
+                let tx = tnt_token.transfer(blueprint_manager, value);
                 let receipt = tx.send().await.unwrap().get_receipt().await.unwrap();
                 assert!(
                     receipt.status(),
@@ -304,7 +303,7 @@ mod e2e {
 
                 // Double check that the Blueprint manager contract has been funded with TNT.
                 let balance = tnt_token.balanceOf(blueprint_manager).call().await.unwrap();
-                assert_eq!(balance._0, value.into());
+                assert_eq!(balance._0, value);
 
                 let service = svcs.services.last().unwrap();
 

--- a/src/keygen.rs
+++ b/src/keygen.rs
@@ -186,11 +186,15 @@ where
     Ok(verifying_key)
 }
 
-#[cfg(all(test, feature = "e2e"))]
+// #[cfg(all(test, feature = "e2e"))]
+#[cfg(test)]
 mod e2e {
+    use alloy_primitives::U256;
+    use alloy_sol_types::sol;
     use api::runtime_types::bounded_collections::bounded_vec::BoundedVec;
     use api::runtime_types::tangle_primitives::services::field::BoundedString;
     use api::runtime_types::tangle_primitives::services::field::Field;
+    use api::runtime_types::tangle_primitives::services::BlueprintManager;
     use api::services::calls::types::call::Args;
     use blueprint_test_utils::test_ext::*;
     use blueprint_test_utils::*;
@@ -213,6 +217,17 @@ mod e2e {
             .try_init();
     }
 
+    sol!(
+        #[sol(rpc)]
+        "contracts/src/FrostBlueprint.sol",
+    );
+
+    sol!(
+        #[sol(rpc)]
+        IERC20,
+        "contracts/out/ERC20/IERC20.sol/IERC20.json",
+    );
+
     #[tokio::test(flavor = "multi_thread")]
     #[allow(clippy::needless_return)]
     async fn keygen() {
@@ -225,10 +240,14 @@ mod e2e {
 
         let manifest_path = base_path.join("Cargo.toml");
 
+        let ws_port = tangle.ws_port();
+        let http_rpc_url = format!("http://127.0.0.1:{ws_port}");
+        let ws_rpc_url = format!("ws://127.0.0.1:{ws_port}");
+
         let opts = Opts {
             pkg_name: option_env!("CARGO_BIN_NAME").map(ToOwned::to_owned),
-            http_rpc_url: format!("http://127.0.0.1:{}", tangle.ws_port()),
-            ws_rpc_url: format!("ws://127.0.0.1:{}", tangle.ws_port()),
+            http_rpc_url,
+            ws_rpc_url,
             manifest_path,
             signer: None,
             signer_evm: None,
@@ -245,6 +264,47 @@ mod e2e {
                 // as an operator for the relevant services, and, all gadgets are running
 
                 let keypair = handles[0].sr25519_id().clone();
+
+                // Fund the Blueprint manager contract with Some TNT.
+                let blueprint_manager = match svcs.blueprint.manager {
+                    BlueprintManager::Evm(contract_address) => contract_address.0.into(),
+                };
+
+                let tnt = 500;
+                let value = U256::from(tnt) * U256::from(10).pow(U256::from(18));
+
+                let signer = cargo_tangle::signer::load_evm_signer_from_env().unwrap();
+
+                let wallet = alloy_network::EthereumWallet::from(signer);
+
+                let ws_rpc_url = format!("ws://127.0.0.1:{ws_port}");
+                let provider = alloy_provider::ProviderBuilder::new()
+                    .with_recommended_fillers()
+                    .wallet(wallet)
+                    .on_ws(alloy_provider::WsConnect::new(ws_rpc_url))
+                    .await
+                    .unwrap();
+
+                let frost_blueprint = FrostBlueprint::new(blueprint_manager, provider.clone());
+                let tnt_token_address = frost_blueprint
+                    .TNT_ERC20_ADDRESS()
+                    .call()
+                    .await
+                    .map(|t| t.TNT_ERC20_ADDRESS)
+                    .unwrap();
+                let tnt_token = IERC20::new(tnt_token_address, provider.clone());
+
+                // Send Some TNT to the Blueprint manager contract.
+                let tx = tnt_token.transfer(blueprint_manager, value.into());
+                let receipt = tx.send().await.unwrap().get_receipt().await.unwrap();
+                assert!(
+                    receipt.status(),
+                    "Failed to fund the Blueprint manager contract with TNT"
+                );
+
+                // Double check that the Blueprint manager contract has been funded with TNT.
+                let balance = tnt_token.balanceOf(blueprint_manager).call().await.unwrap();
+                assert_eq!(balance._0, value.into());
 
                 let service = svcs.services.last().unwrap();
 

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -231,6 +231,9 @@ where
 
 #[cfg(all(test, feature = "e2e"))]
 mod e2e {
+    use crate::api::runtime_types::tangle_primitives::services::BlueprintManager;
+    use alloy_primitives::U256;
+    use alloy_sol_types::sol;
     use api::runtime_types::bounded_collections::bounded_vec::BoundedVec;
     use api::runtime_types::tangle_primitives::services::field::BoundedString;
     use api::runtime_types::tangle_primitives::services::field::Field;
@@ -244,6 +247,17 @@ mod e2e {
 
     use super::*;
 
+    sol!(
+        #[sol(rpc)]
+        "contracts/src/FrostBlueprint.sol",
+    );
+
+    sol!(
+        #[sol(rpc)]
+        IERC20,
+        "contracts/out/ERC20/IERC20.sol/IERC20.json",
+    );
+
     #[tokio::test(flavor = "multi_thread")]
     #[allow(clippy::needless_return)]
     async fn signing() {
@@ -256,10 +270,14 @@ mod e2e {
 
         let manifest_path = base_path.join("Cargo.toml");
 
+        let ws_port = tangle.ws_port();
+        let http_rpc_url = format!("http://127.0.0.1:{ws_port}");
+        let ws_rpc_url = format!("ws://127.0.0.1:{ws_port}");
+
         let opts = Opts {
             pkg_name: option_env!("CARGO_BIN_NAME").map(ToOwned::to_owned),
-            http_rpc_url: format!("http://127.0.0.1:{}", tangle.ws_port()),
-            ws_rpc_url: format!("ws://127.0.0.1:{}", tangle.ws_port()),
+            http_rpc_url,
+            ws_rpc_url,
             manifest_path,
             signer: None,
             signer_evm: None,
@@ -280,6 +298,47 @@ mod e2e {
             // as an operator for the relevant services, and, all gadgets are running
 
             let keypair = handles[0].sr25519_id().clone();
+
+            // Fund the Blueprint manager contract with Some TNT.
+            let blueprint_manager = match svcs.blueprint.manager {
+                BlueprintManager::Evm(contract_address) => contract_address.0.into(),
+            };
+
+            let tnt = 500;
+            let value = U256::from(tnt) * U256::from(10).pow(U256::from(18));
+
+            let signer = cargo_tangle::signer::load_evm_signer_from_env().unwrap();
+
+            let wallet = alloy_network::EthereumWallet::from(signer);
+
+            let ws_rpc_url = format!("ws://127.0.0.1:{ws_port}");
+            let provider = alloy_provider::ProviderBuilder::new()
+                .with_recommended_fillers()
+                .wallet(wallet)
+                .on_ws(alloy_provider::WsConnect::new(ws_rpc_url))
+                .await
+                .unwrap();
+
+            let frost_blueprint = FrostBlueprint::new(blueprint_manager, provider.clone());
+            let tnt_token_address = frost_blueprint
+                .TNT_ERC20_ADDRESS()
+                .call()
+                .await
+                .map(|t| t.TNT_ERC20_ADDRESS)
+                .unwrap();
+            let tnt_token = IERC20::new(tnt_token_address, provider.clone());
+
+            // Send Some TNT to the Blueprint manager contract.
+            let tx = tnt_token
+                .transfer(blueprint_manager, value.into());
+            let receipt = tx.send().await.unwrap().get_receipt().await.unwrap();
+            assert!(receipt.status(), "Failed to fund the Blueprint manager contract with TNT");
+
+
+            // Double check that the Blueprint manager contract has been funded with TNT.
+            let balance = tnt_token.balanceOf(blueprint_manager).call().await.unwrap();
+            assert_eq!(balance._0, value.into());
+
 
             let service = svcs.services.last().unwrap();
             let service_id = service.id;

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -254,8 +254,8 @@ mod e2e {
 
     sol!(
         #[sol(rpc)]
-        IERC20,
-        "contracts/out/ERC20/IERC20.sol/IERC20.json",
+        ERC20,
+        "contracts/out/ERC20.sol/ERC20.json"
     );
 
     #[tokio::test(flavor = "multi_thread")]
@@ -326,18 +326,18 @@ mod e2e {
                 .await
                 .map(|t| t.TNT_ERC20_ADDRESS)
                 .unwrap();
-            let tnt_token = IERC20::new(tnt_token_address, provider.clone());
+            let tnt_token = ERC20::new(tnt_token_address, provider.clone());
 
             // Send Some TNT to the Blueprint manager contract.
             let tx = tnt_token
-                .transfer(blueprint_manager, value.into());
+                .transfer(blueprint_manager, value);
             let receipt = tx.send().await.unwrap().get_receipt().await.unwrap();
             assert!(receipt.status(), "Failed to fund the Blueprint manager contract with TNT");
 
 
             // Double check that the Blueprint manager contract has been funded with TNT.
             let balance = tnt_token.balanceOf(blueprint_manager).call().await.unwrap();
-            assert_eq!(balance._0, value.into());
+            assert_eq!(balance._0, value);
 
 
             let service = svcs.services.last().unwrap();


### PR DESCRIPTION
This pull request introduces significant enhancements to the `FrostBlueprint` contract and adds a new `IPaymentManager` interface. The key changes include the integration of payment management functionalities, the addition of new constants, storage variables, events, and error definitions, as well as the implementation of several new functions to handle job results and manage service operators.

### Enhancements to `FrostBlueprint` contract:

* Integrated `PaymentManagerBase` to manage payments and added the necessary imports for `EnumerableMap` and `IPaymentManager`.
* Defined new constants for job IDs and durations, added storage mappings for service operators and job costs, and declared events and errors.
* Implemented new functions to handle job results (`_handleKeygenJobResult` and `_handleSignJobResult`), calculate service costs, update job costs, and manage service operators.
* Updated the `operatorAddressFromPublicKey` function to be public and added internal functions for handling job results and adding service operators.

### New `IPaymentManager` interface:

* Defined the `IPaymentManager` interface to manage payments, including functions for adding/removing supported tokens, checking balances, crediting operators, depositing and withdrawing tokens, and calculating service costs.

### Workflow

![image](https://github.com/user-attachments/assets/bf7dc0be-7623-4df3-a959-e372415a1a49)


- Blueprint Developer Deploys the Blueprint
- Blueprint Developer Can Set/Update supported set of tokens
- Customers needs to pay Up front in any (one or more) of the supported tokens
- Customers could ask the blueprint manager for a cost of service before the payment
- Operators register on the blueprint from the runtime, and they get assigned OPERATOR_ROLE
- Customers could request services as long as they have enough funds to cover this service.
- Customers is able to call jobs on the service from the runtime
- Operators submit job results to the runtime.
- Blueprint Manager (optionally) verifies the job results and credit the operator(s)
- Operators (at any point of time) could claim and withdraw their credits

### TODOs or Open Questions
 - Currently, we do not have access to the `serviceOwner` which is need to account for their credits/deposits (see https://github.com/tangle-network/tangle/issues/817)
 - Native Payments (TNT) needs https://github.com/tangle-network/tangle/issues/818
 - Should we support refunds? i.e service owner could terminate their service early and thus they can claim the remaining funds.
 - To support the above point, we may need adding more hooks (`onTerminate` with a reason)
 - Since every service could select a set of supported asset ids when requested, we should check if the selected asset ids are a subset of the supported assets/tokens declared by the blueprint developer.
 - if the above case is supported, we must keep track of each service specific supported assets/tokens, which will be always a subset of the supported tokens by the blueprint itself.
 - Need to consider this when removing a supported asset from the blueprint manager. 