### PR TITLE
chore(deps): bump blueprint-sdk to v0.2.0-alpha.5 (crates.io)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ name = "frost-blueprint"
 path = "src/main.rs"
 
 [dependencies]
-blueprint-sdk = { git = "https://github.com/tangle-network/blueprint.git", branch = "main", default-features = false, features = [
+blueprint-sdk = { version = "0.2.0-alpha.5", default-features = false, features = [
     "std",
     "tracing",
     "macros",
@@ -45,7 +45,7 @@ frost-secp256k1 = { version = "2.0", default-features = false, features = ["seri
 round-based = { version = "0.4.1", features = ["runtime-tokio", "derive"] }
 
 [dev-dependencies]
-blueprint-sdk = { git = "https://github.com/tangle-network/blueprint.git", branch = "main", default-features = false, features = ["std", "tangle", "testing", "networking", "round-based-compat"] }
+blueprint-sdk = { version = "0.2.0-alpha.5", default-features = false, features = ["std", "tangle", "testing", "networking", "round-based-compat"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "test-util"] }
 tracing-subscriber = "0.3"
 


### PR DESCRIPTION
Switches `blueprint-*` deps from `branch = main` git refs onto pinned crates.io versions. Picks up the audit follow-up batch (M-2 / H-1 / F-001 + governance-tunable operator cap) via tnt-core-bindings v0.17.1.

Bumps `rust-toolchain.toml` to 1.91 to match the new SDK MSRV.