### PR TITLE
revert(deps): rand 0.8.6 → 0.9.4 (PR #152) — frost-core still on rand_core 0.6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,17 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 5
+    ignore:
+      # frost-core 3.0.0 (latest) still pins rand_core ^0.6, so any
+      # `rand` major bump past 0.8.x produces an unbuildable graph
+      # (rand_core 0.6 vs 0.9 trait mismatch). Re-enable once frost-core
+      # upstreams rand 0.9. Tracking: ZcashFoundation/frost.
+      - dependency-name: "rand"
+        update-types: ["version-update:semver-major"]
+      # rand_chacha is on 0.3 (rand 0.8 era) for the same reason — its
+      # SeedableRng impls feed frost-core's RngCore + CryptoRng bounds.
+      - dependency-name: "rand_chacha"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     allow:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3740,7 +3740,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4557,7 +4557,7 @@ dependencies = [
  "futures",
  "hex",
  "libp2p 0.56.0",
- "rand 0.9.4",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "round-based",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-rand = "0.9"
+rand = "0.8"
 rand_chacha = "0.3"
 futures = "0.3"
 libp2p = { version = "0.56", default-features = false }


### PR DESCRIPTION
## Summary

Reverts #152. Main currently does not compile.

## Why

`frost-core` **3.0.0** (latest stable, released 2026-04-23) still declares `rand_core ^0.6` as a normal dependency. Bumping `rand` to `0.9.4` pulled in `rand_core 0.9.5` for our crate while frost-core kept compiling against `rand_core 0.6` — so the public bound on `dkg::part1`/`round1::commit` (`R: RngCore + CryptoRng`) refers to a different `RngCore` than the `OsRng` we hand it.

Local build of `main` produces 17 errors, e.g.:

```
error[E0277]: the trait bound `rand::rngs::OsRng: rand::RngCore` is not satisfied
error[E0277]: the trait bound `R: rand_chacha::rand_core::RngCore` is not satisfied
  = note: there are multiple different versions of crate `rand_core` in the dependency graph
  = note: required by a bound in `frost_core::keys::dkg::part1`
error[E0599]: no function or associated item named `from_seed` found for struct `ChaCha20Rng`
```

There is no in-repo migration that fixes this — the bound is part of frost-core's public API. We're blocked at upstream until ZcashFoundation/frost releases a rand 0.9-compatible version.

## What this PR does

1. Reverts `3f4fd1c` (PR #152).
2. Adds a dependabot ignore for `rand` and `rand_chacha` **major-version bumps** only — patch/minor flow through as before.

Drop the ignore once frost-core 3.x.y ships with `rand_core ^0.9`.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace --no-run` — clean
- [ ] CI confirms green on this branch